### PR TITLE
fix: react coll dimensions type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "react": "^17.0.0",
-    "react-cool-dimensions": "^1.3.2",
+    "react-cool-dimensions": "1.3.4",
     "react-dom": "^17.0.0",
     "react-router-dom": "^5.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,10 +2052,10 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-react-cool-dimensions@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/react-cool-dimensions/-/react-cool-dimensions-1.3.2.tgz#a25543da0cd8ce11e08e8e9c727e89285018e9b4"
-  integrity sha512-s2d2DxWkpqUm4r+gINmHTduzWDYHf4xiPjbC72MDf+3p/rYXpyNDfF8xrdgD8h2ZyK3sfLd9zWjnYzrroUxf1w==
+react-cool-dimensions@1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/react-cool-dimensions/-/react-cool-dimensions-1.3.4.tgz#f8c4b868c9e4e3f4f1f436de74ce01b82e3f0fa6"
+  integrity sha512-dOHAPfLwaKuy7hcZ5dIv7sulrH4VfEP1B/m591gUCGenut3Iqf7Qi7xPT54EFJDaNRrBdqHLCttRgktvOyzoaQ==
 
 react-dom@^17.0.0:
   version "17.0.1"


### PR DESCRIPTION
Fix following error.

```
yarn build
yarn run v1.22.10
warning package.json: No license field
$ tsc && vite build
node_modules/react-cool-dimensions/dist/index.d.ts:48:25 - error TS2344: Type 'T' does not satisfy the constraint 'HTMLElement'.

48     onResize?: OnResize<T>;
                           ~

node_modules/react-cool-dimensions/dist/index.d.ts:52:42 - error TS2344: Type 'T' does not satisfy the constraint 'HTMLElement'.

52   interface Return<T> extends Omit<Event<T>, "entry"> {
                                            ~


Found 2 errors.
```

Maybe this PR will fix #2 